### PR TITLE
Added the Possibility to directly pass a string.

### DIFF
--- a/src/main/java/org/qlrm/executor/JdbcQueryExecutor.java
+++ b/src/main/java/org/qlrm/executor/JdbcQueryExecutor.java
@@ -1,19 +1,19 @@
 package org.qlrm.executor;
 
-import org.qlrm.mapper.JdbcResultMapper;
-
 import java.sql.Connection;
 import java.sql.PreparedStatement;
 import java.sql.ResultSet;
 import java.sql.SQLException;
 import java.util.List;
 
+import org.qlrm.mapper.JdbcResultMapper;
+
 public class JdbcQueryExecutor {
 
     private final JdbcResultMapper jdbcResultMapper = new JdbcResultMapper();
 
     /**
-     * Executes an SQL select from a file an returns objects of the requested class
+     * Executes an SQL select from a file and returns objects of the requested class
      *
      * @param connection {@link java.sql.Connection}
      * @param clazz      Type to return
@@ -23,8 +23,22 @@ public class JdbcQueryExecutor {
      * @return List of objects
      */
     public <T> List<T> executeSelect(Connection connection, Class<T> clazz, String filename, Object... params) {
+        String sqlString = FileUtil.getFileAsString(filename);
+        return executeSelect(connection, sqlString, clazz, params);
+    }
+
+    /**
+     * Executes an SQL select  and returns objects of the requested class
+     *
+     * @param connection {@link java.sql.Connection}
+     * @param clazz      Type to return
+     * @param filename   File containing the SQL select
+     * @param params     List of parameters
+     * @param <T>
+     * @return List of objects
+     */
+    public <T> List<T> executeSelect(Connection connection, String sqlString, Class<T> clazz, Object... params) {
         try {
-            String sqlString = FileUtil.getFileAsString(filename);
             PreparedStatement prepareStatement = connection.prepareStatement(sqlString);
 
             if (params.length > 0) {

--- a/src/test/java/org/qlrm/executor/JdbcQueryExecutorTest.java
+++ b/src/test/java/org/qlrm/executor/JdbcQueryExecutorTest.java
@@ -1,13 +1,13 @@
 package org.qlrm.executor;
 
+import java.util.List;
+
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 import org.junit.Assert;
 import org.junit.Test;
 import org.qlrm.test.JdbcBaseTest;
 import org.qlrm.to.EmployeeTO;
-
-import java.util.List;
 
 public class JdbcQueryExecutorTest extends JdbcBaseTest {
 
@@ -18,6 +18,20 @@ public class JdbcQueryExecutorTest extends JdbcBaseTest {
         JdbcQueryExecutor queryExecutor = new JdbcQueryExecutor();
 
         List<EmployeeTO> list = queryExecutor.executeSelect(con, EmployeeTO.class, "select.sql");
+
+        Assert.assertNotNull(list);
+        Assert.assertTrue(list.size() > 0);
+
+        for (EmployeeTO rec : list) {
+            LOGGER.debug(rec);
+        }
+    }
+
+    @Test
+    public void shouldEnsureDirectSqlApi() {
+        JdbcQueryExecutor queryExecutor = new JdbcQueryExecutor();
+
+        List<EmployeeTO> list = queryExecutor.executeSelect(con, "SELECT ID, NAME FROM EMPLOYEE", EmployeeTO.class);
 
         Assert.assertNotNull(list);
         Assert.assertTrue(list.size() > 0);


### PR DESCRIPTION
I would like to pass the sql as a string.

Just as a hint, we had problems with the paging of the JPA under Oracle. With about 80 million records the total number was correct but some records were returned twice. The number of duplicates differed per run between 10k and 1 million. 
Not with your code but with the same principle of setFirstResult & setMaxResults. 
